### PR TITLE
Update OG meta image url and description

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
         <meta property="og:title" content="MUN Anime Society" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://mun-anime.com/" />
-        <meta property="og:image" content="club-logo.png" />
-        <meta property="og:description" content="Website for the MUN Anime Society." />
+        <meta property="og:image" content="https://mun-anime.com/club-logo.png" />
+        <meta property="og:description" content="The MUN Anime Film Club is a community focused around Japanese pop-culture, with a primary focus on anime and manga. Through weekly Friday showings and other events that are open to everyone..." />
     </head>
     <body>
         <h1 id="title"><a href="index.html">MUN Anime Society</a></h1>


### PR DESCRIPTION
- OG meta doesn't seem to like relative URLs, so I updated the image url to contain the full path
- The OG meta description is now longer and contains the first bit of the website's About section